### PR TITLE
Added Travis Usage Example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ language: generic
 services: docker
 
 script:
-- docker run --rm -it -v $(pwd):/home koppor/texlive latexmk -pdf document.tex
+- docker run --rm -it -v $(pwd):/home danteev/texlive latexmk -pdf document.tex
 ```
 
 ## Latest stable version

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This docker image supports full TeX Live 2017 with following additions:
 
 Usage:
 
-    docker run --rm -it -v $(pwd):/home danteev/texlive latexmk document.tex
+    docker run --rm -it -v $(pwd):/home danteev/texlive latexmk -pdf document.tex
 
 Usage in [CircleCI 2.0](https://circleci.com/docs/2.0/):
 
@@ -28,7 +28,20 @@ jobs:
        - image: danteev/texlive
      steps:
        - checkout
-       - run: latexmk document.tex
+       - run: latexmk -pdf document.tex
+```
+
+Usage in [Travis CI](https://travis-ci.org/):
+
+Create file `.travis.yml` with following content:
+
+```yaml
+dist: bionic
+language: generic
+services: docker
+
+script:
+- docker run --rm -it -v $(pwd):/home koppor/texlive latexmk -pdf document.tex
 ```
 
 ## Latest stable version


### PR DESCRIPTION
Hi,
I'm using this container in my projects, but since I mostly use Travis CI, I thought it would be nice to have a usage example for Travis as well in the `README`.

Additionally, I added the `-pdf` flag for `latexmk`, since I guess nobody is interested in building a `DVI` anymore.

Cheers,
Linus