### PR TITLE
Add an example of use with a custom build script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ jobs:
           root_file: document.tex
 ```
 
+Or for custom tex compilation script :
+
+```yaml
+name: Build
+on:
+  push:
+    paths-ignore:
+      - '*.pdf'
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    container:
+      image: danteev/texlive:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build LaTeX
+      run: |
+        for project in $(ls); do
+          if [ -d "$project" ]; then 
+            cd ${project}
+            latexmk -synctex=1 -interaction=nonstopmode -file-line-error -pdf -outdir=$PWD/../ $PWD/${project}
+            cd ..
+          fi
+        done
+```
+
 ### Usage in [CircleCI 2.0](https://circleci.com/docs/2.0/):
 
 Create file `.circle/config.yml` with following content:


### PR DESCRIPTION
This example can be very useful for example if you have multiple tex project to build.

Personnally, I use it to build all tex project disposed like that : 
```sh
❯ tree
.
├── motivation_letter.pdf
├── master_degree.pdf
├── README.md
├── master_degree
│   ├── master_degree.sty
│   └── master_degree.tex
└── motivation_letter
    ├── motivation_letter.bib
    └── motivation_letter.tex
```

That build all my tex files and put in into the root dir.
To push it to my github repository, I add this step : 
```yaml
- name: Publish LaTeX
      run : |
        git config --global user.email "bot@nocturlab.fr"
        git config --global user.name "BOT_WORKFLOW"
        git add -f $PWD/*.pdf
        git commit -m "WORKFLOW_COMMIT - Update PDFs [skip ci]"
        git push
```