### PR TITLE
feat: add git-latexdiff v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for [fig2dev](https://linux.die.net/man/1/fig2dev)
 - Added support for [pandoc](https://pandoc.org/)
 - Remove more space after installing debian packages
+- Added support for [git-latexdiff](https://gitlab.com/git-latexdiff/git-latexdiff)
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV INITRD No
 
 ARG BUILD_DATE
+ARG GITLATEXDIFF_VERSION=1.6.0
 
 # Fix for update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
 # See https://github.com/debuerreotype/docker-debian-artifacts/issues/24#issuecomment-360870939
@@ -85,6 +86,6 @@ RUN wget -q https://raw.githubusercontent.com/bastien-roucaries/latex-pax/0a4fc9
 RUN wget https://gitlab.com/Lotz/pkgcheck/raw/master/bin/pkgcheck -q --output-document=/usr/local/bin/pkgcheck && chmod a+x /usr/local/bin/pkgcheck
 
 # Install git-latexdiff v1.6.0 https://gitlab.com/git-latexdiff/git-latexdiff
-RUN git clone --branch 1.6.0 https://gitlab.com/git-latexdiff/git-latexdiff.git /tmp/git-latexdiff && \
+RUN git clone --branch "$GITLATEXDIFF_VERSION" https://gitlab.com/git-latexdiff/git-latexdiff.git /tmp/git-latexdiff && \
     make -C /tmp/git-latexdiff install-bin && \
     rm -rf /tmp/git-latexdiff

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,6 @@ RUN wget -q https://raw.githubusercontent.com/bastien-roucaries/latex-pax/0a4fc9
 RUN wget https://gitlab.com/Lotz/pkgcheck/raw/master/bin/pkgcheck -q --output-document=/usr/local/bin/pkgcheck && chmod a+x /usr/local/bin/pkgcheck
 
 # Install git-latexdiff v1.6.0 https://gitlab.com/git-latexdiff/git-latexdiff
-RUN git clone --branch "$GITLATEXDIFF_VERSION" https://gitlab.com/git-latexdiff/git-latexdiff.git /tmp/git-latexdiff && \
+RUN git clone --branch "$GITLATEXDIFF_VERSION" --depth=1 https://gitlab.com/git-latexdiff/git-latexdiff.git /tmp/git-latexdiff && \
     make -C /tmp/git-latexdiff install-bin && \
     rm -rf /tmp/git-latexdiff

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,3 +83,8 @@ RUN wget -q https://raw.githubusercontent.com/bastien-roucaries/latex-pax/0a4fc9
 
 # install pkgcheck
 RUN wget https://gitlab.com/Lotz/pkgcheck/raw/master/bin/pkgcheck -q --output-document=/usr/local/bin/pkgcheck && chmod a+x /usr/local/bin/pkgcheck
+
+# Install git-latexdiff v1.6.0 https://gitlab.com/git-latexdiff/git-latexdiff
+RUN git clone --branch 1.6.0 https://gitlab.com/git-latexdiff/git-latexdiff.git /tmp/git-latexdiff && \
+    make -C /tmp/git-latexdiff install-bin && \
+    rm -rf /tmp/git-latexdiff

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This docker image supports full TeX Live 2019 with following additions:
 - [pax](http://ctan.org/pkg/pax)
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/)
 - [Python 3](https://pythonclock.org/), pip, pyparsing, python-docx
+- [git-latexdiff](https://gitlab.com/git-latexdiff/git-latexdiff)
 
 ## Usage
 


### PR DESCRIPTION
This PR adds [git-latexdiff](https://gitlab.com/git-latexdiff/git-latexdiff) `v1.6.0` to the docker image.

> git-latexdiff is a tool to graphically visualize differences between different versions of a LaTeX file. Technically, it is a wrapper around git and latexdiff.

Looking forward for feedback :)