### PR TITLE
Fix build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Instead, we version `YYYY-RR`, where `YYYY` is TeXLive version this image is bas
 
 - Added support for luximono
 
+## Changed
+
+- Switch upstream image to [Island of TeX's texlive image](https://gitlab.com/islandoftex/images/texlive)
+- Update pandoc to 2.12.1
+
 ## [2020-01] &ndash; 2020-06-23
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
 # install luximono
-RUN cd /tmp && wget https://www.tug.org/fonts/getnonfreefonts/install-getnonfreefonts && texlua install-getnonfreefonts && getnonfreefonts --sys luximono
+# RUN cd /tmp && wget https://www.tug.org/fonts/getnonfreefonts/install-getnonfreefonts && texlua install-getnonfreefonts && getnonfreefonts --sys luximono
 
 # update font index
-RUN luaotfload-tool --update
+# RUN luaotfload-tool --update

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /home
 RUN mkdir -p /usr/share/man/man1
 
 # pandoc in the repositories is older - we just overwrite it with a more recent version
-RUN wget https://github.com/jgm/pandoc/releases/download/2.11.3.2/pandoc-2.11.3.2-1-amd64.deb -q --output-document=/home/pandoc.deb && dpkg -i pandoc.deb && rm pandoc.deb
+RUN wget https://github.com/jgm/pandoc/releases/download/2.12/pandoc-2.12-1-amd64.deb -q --output-document=/home/pandoc.deb && dpkg -i pandoc.deb && rm pandoc.deb
 
 # get PlantUML in place
 RUN wget https://netcologne.dl.sourceforge.net/project/plantuml/plantuml.jar -q --output-document=/home/plantuml.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,6 @@ ENV LANG=C.UTF-8 \
 ARG BUILD_DATE
 ARG GITLATEXDIFF_VERSION=1.6.0
 
-# Mark Debian packages "provided" by texlive:latest as installed
-# Idea from https://tex.stackexchange.com/a/95373/9075
-RUN apt-get update && \
-    apt install -qy equivs --no-install-recommends freeglut3 && \
-    mkdir -p /tmp/tl-equivs && cd /tmp/tl-equivs && \
-    wget -O texlive-local http://www.tug.org/texlive/files/debian-equivs-2020-ex.txt && \
-    equivs-build texlive-local && \
-    dpkg -i texlive-local_2020-1_all.deb && \
-    apt install -qyf && \
-    apt remove -y --purge equivs freeglut3 && \
-    apt-get autoremove -qy --purge && \
-    # save some space
-    rm -rf /var/lib/apt/lists/* && apt-get clean
-
 WORKDIR /home
 
 # Fix for update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory


### PR DESCRIPTION
Tries to fix the build. Currently, the installation of `latexml` breaks `luaotfload`. This is fixed at https://gitlab.com/islandoftex/images/texlive/-/merge_requests/7. We have to wait until that is merged.

Other issue is propably following:

---

I am installing texlive as explained at https://askubuntu.com/a/218294/196423 and https://askubuntu.com/a/465009/196423. I am using the "Provides" configuration from https://www.tug.org/texlive/files/debian-equivs-2020-ex.txt.

When checking texlive-music, aptitude shows two versions:

```
i texlive-local 2020-1
p 2020.20210202-1
```

If I select texlive-music for installation, apt wants to install it, even if it should be provided by texlive-local:

```
  apt-cache showpkg texlive-music
Package: texlive-music
Versions:
2020.20210202-1 (/var/lib/apt/lists/deb.debian.org_debian_dists_testing_main_binary-amd64_Packages.lz4)
 Description Language:
                 File: /var/lib/apt/lists/deb.debian.org_debian_dists_testing_main_binary-amd64_Packages.lz4
                  MD5: 2cb0a7240baea8353afb0bd636b2ec79


Reverse Depends:
  texlive-base,texlive-music 2020.20200417
  texlive-full,texlive-music 2020.20200417
Dependencies:
2020.20210202-1 - tex-common (2 6.13) python3 (0 (null)) texlive-base (2 2020.20200417) texlive-binaries (2 2020.20200327) texlive-latex-base (2 2020.20200417) gregorio (1 2.3-1) gregoriotex (1 2.3-1) m-tx (3 0.61.ctan20151217-2) musixtex (3 1:1.20.ctan20151216-3) pmx (3 2.7.0.ctan20150301-3) texlive-base (3 2020.20200417) m-tx (3 0.61.ctan20151217-2) musixtex (3 1:1.20.ctan20151216-3) pmx (3 2.7.0.ctan20150301-3)
Provides:
2020.20210202-1 - pmx (= ) musixtex (= ) m-tx (= ) gregoriotex (= ) gregorio (= )
Reverse Provides:
texlive-local 2020-1 (= )

# apt install texlive-music
...
The following additional packages will be installed:
...
texlive-base
...
```

Hint: https://askubuntu.com/q/18654/196423