### PR TITLE
Prepare 2021-D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Note that this version is continuosly built based on [texlive/texlive](https://g
 
 - Switch back to `latest` of the [upstream texlive image](https://gitlab.com/islandoftex/images/texlive)
 
+## [2021-D] &ndash; 2021-09-19
+
+### Changed
+
+- Uses tag `TL2021-2021-08-01-04-07` of the [upstream texlive image](https://gitlab.com/islandoftex/images/texlive)
+
 ## [2020-A] &ndash; 2021-09-18
 
 ### Changed
@@ -160,6 +166,7 @@ Note that this version is continuosly built based on [texlive/texlive](https://g
 Initial release
 
 [edge]: https://github.com/koppor/docker-texlive/compare/2021-B...HEAD
+[2021-D]: https://github.com/koppor/docker-texlive/compare/2021-C...2021-D
 [2021-C]: https://github.com/koppor/docker-texlive/compare/2021-B...2021-C
 [2021-B]: https://github.com/koppor/docker-texlive/compare/2021-A...2021-B
 [2021-A]: https://github.com/koppor/docker-texlive/compare/2020...2021-A

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/islandoftex/images/texlive:latest
+FROM registry.gitlab.com/islandoftex/images/texlive:TL2021-2021-09-19-04-05
 
 LABEL \
   org.opencontainers.image.title="Full TeX Live with additions" \

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ build:
       - document.pdf
 ```
 
-## Available Tags
+## Available tags
 
 - `edge` - the edge build. Usually created on the first and fifteenth of a month.
 - `latest` - the latest released version
@@ -175,6 +175,13 @@ docker run --rm -it -v $(pwd):/workdir danteev/texlive:2021-05-15 latexmk docume
 
 We decided to base on the official texlive image, because this ensures recent texlive packages and a working basic build.
 We extended the image with tools required for our use cases.
+
+## Development hints
+
+- At a release, we point to a specific tag of the "upstream" Docker image.
+  To find out the lasest tag there, follow the instructions at <https://gitlab.com/islandoftex/images/texlive/-/issues/9>.
+  Search for `build:latest: [2021, no, no]` in the build jobs.
+  `no, no` means: no documentation and no source files.
 
 ## Alternatives
 


### PR DESCRIPTION
Fixes https://github.com/dante-ev/docker-texlive/issues/43

I released 2020-A yesterday (and 2019-A on 2021-09-15). Due to the magic of the [docker-metadata-action](https://github.com/crazy-max/docker-metadata-action#basic), the `latest` tag was set to these versions. Thus, a new 2021 version needs to be released to have the `latest` tag working again.