### PR TITLE
fix: fix GitHub Actions build pipeline

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           docker run -v $(pwd)/..:/workdir localhost:5000/name/app:latest /bin/bash -c "cd subdir1 && lualatex current-file.tex"
       - name: Archive PDFs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pdfs
           path: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,7 @@ RUN apt-get update -q && \
     apt-get install -qqy -o=Dpkg::Use-Pty=0 --no-install-recommends git wget && \
     # Install Ruby's bundler
     apt-get install -qqy -o=Dpkg::Use-Pty=0 ruby poppler-utils && gem install bundler && \
-    # openjdk-8-jre-headless is currently not available in testing
-    # solution by https://stackoverflow.com/a/61902164/873282
-    apt-get install -qqy -o=Dpkg::Use-Pty=0 software-properties-common && \
-    apt-get update && \
-    # plantuml requires java8
+    # plantuml requires java17
     apt-get install -qqy -o=Dpkg::Use-Pty=0 --no-install-recommends openjdk-17-jre-headless && \
     # proposal by https://github.com/sumandoc/TeXLive-2017
     apt-get install -qqy -o=Dpkg::Use-Pty=0 curl libgetopt-long-descriptive-perl libdigest-perl-md5-perl fontconfig && \


### PR DESCRIPTION
Related to #52 

- Updates upload-artifact workflow to v4 because v2 is [deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
- Removes installation of package `software-properties-common` as it is [no longer available in Debian testing](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1088285) and I assume the workaround is no longer needed anyway since 343ccd4d7587e0b22628b3746da158a9cabda2dc(?)

Tested successfully on my fork.