### PR TITLE
Add QEMU to build action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,12 +45,15 @@ jobs:
           registry: ghcr.io
           username: koppor
           password: ${{ secrets.CR_PAT }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Image digest


### PR DESCRIPTION
Overlooked that QEMU needs to be set up for multi-platform builds... sorry.

Should fix issue in https://github.com/dante-ev/docker-texlive/pull/54#issuecomment-2655120749